### PR TITLE
Improve CLAUDE.md with nested module references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,78 +2,131 @@
 
 ## Project Overview
 
-This is an ML project for predicting Remaining Useful Life (RUL) of NASA turbofan engines using the N-CMAPSS dataset. It provides a unified pipeline with 14 neural network architectures, automatic data loading, and W&B experiment tracking.
-
-## Development Workflow
-
-1. **Create a GitHub issue** with a full description of the work to be done
-2. **Create a feature branch** from main to work on the issue
-3. **Develop and commit** changes to the branch
-4. **Open a PR** when work is complete, referencing the issue
-5. **Wait for CI to pass** before merging
-6. **Merge** the PR into main
+ML project for predicting Remaining Useful Life (RUL) of NASA turbofan engines using the N-CMAPSS dataset. Unified pipeline with 15 neural network architectures, automatic data loading, and W&B experiment tracking. Best model: CNN-GRU + asymmetric loss (RMSE 6.44, R² 0.91, Acc@20 99.1%). See [EXPERIMENTS.md](EXPERIMENTS.md) for full results.
 
 ## Quick Commands
 
 ```bash
-# Install dependencies
-make install-dev   # or: uv sync
+# Setup
+make install-dev                                    # Install all deps (uv sync)
 
-# Run all checks before committing
-make check         # runs lint + typecheck
+# Code quality (run before every commit)
+make check                                          # Lint + typecheck
+make format                                         # Auto-format with Black
 
-# Format code
-make format
+# Training
+make train                                          # Train default (LSTM, 30 epochs)
+python train_model.py --list-models                 # List all 15 architectures
+python train_model.py --model cnn_gru --epochs 50   # Train specific model
+python train_model.py --model transformer --config transformer_large.json
+python train_model.py --compare --models lstm gru transformer wavenet
+python train_model.py --search-config spec.json --search-workers 4
 
-# Train a model
-make train         # or: python train_model.py --model lstm --epochs 30
+# Inference
+python predict.py --model-path models/production/cnn_gru_best.keras
+python predict.py --model-path models/production/cnn_gru_best.keras --unit-id 5
 
-# List all available models
-python train_model.py --list-models
-
-# Compare multiple models
-python train_model.py --compare --models lstm gru transformer
+# Production
+WANDB_MODE=offline python train_production_model.py  # Train & save best model
+python example_usage.py                              # 5 real-world usage examples
 ```
 
-## CI/CD
+## Environment
 
-GitHub Actions runs on every push/PR to main:
-- **Lint**: Black formatting check
-- **Typecheck**: MyPy static analysis
-- **Matrix**: Python 3.9, 3.10, 3.11
-
-Run `make check` locally before pushing to catch issues early.
+- **Python** 3.8+ (CI tests 3.9, 3.10, 3.11)
+- **TensorFlow/Keras** for all models
+- **uv** for dependency management (`uv sync`)
+- **W&B** for experiment tracking (set `WANDB_MODE=offline` for local-only)
+- **Black** (line-length 100) + **MyPy** (relaxed) for code quality
 
 ## Architecture
 
 ```
 src/
-├── data/load_data.py      # Single data loader using rul_datasets library
-├── models/
-│   ├── architectures.py   # 14 registered models (LSTM, GRU, TCN, Transformer, etc.)
-│   └── __init__.py        # Exports ModelRegistry and train functions
-├── search/hparam_search.py # Grid/random hyperparameter search
-└── utils/
-    ├── metrics.py         # RUL metrics (PHM scoring, RMSE, MAE)
-    └── training_viz.py    # Training plots and visualizations
+├── data/                      # See src/data/CLAUDE.md
+│   └── load_data.py           # get_datasets(fd=1..7) -> train/val/test splits
+├── models/                    # See src/models/CLAUDE.md
+│   ├── architectures.py       # ModelRegistry + 12 built-in architectures
+│   ├── cnn_lstm_attention.py  # 2024 SOTA CNN-LSTM-Attention implementation
+│   ├── mdfa.py                # Multi-Scale Dilated Fusion Attention module
+│   └── __init__.py            # Lazy imports (avoids circular deps)
+├── search/                    # See src/search/CLAUDE.md
+│   └── hparam_search.py       # Grid/random search with parallel execution
+└── utils/                     # See src/utils/CLAUDE.md
+    ├── metrics.py             # RUL metrics (RMSE, MAE, PHM score, accuracy)
+    ├── training_viz.py        # Training history & prediction plots
+    └── visualize.py           # Data analysis & model eval visualizations
 
-train_model.py             # Main CLI entry point
-scripts/                   # Helper scripts for comparisons
+train_model.py                 # Main CLI entry point (~1000 lines)
+predict.py                     # Inference API (RULPredictor class)
+train_production_model.py      # Train & save CNN-GRU for deployment
+scripts/                       # Ad-hoc comparison & summary tools
 ```
 
 ## Key Patterns
 
-- **ModelRegistry**: Models registered via `@ModelRegistry.register("name")` decorator
-- **Single entry point**: All training goes through `train_model.py`
-- **W&B integration**: Automatic logging of metrics, hyperparameters, visualizations
-- **Data auto-download**: First run automatically downloads and caches the dataset
+### ModelRegistry (decorator-based)
 
-## Available Models
+`@ModelRegistry.register("name")` on a class inheriting `BaseModel`. Build any model via `ModelRegistry.build(name, input_shape, **kwargs)`. All models compile with `asymmetric_mse` loss (penalizes late predictions 2x). See [src/models/CLAUDE.md](src/models/CLAUDE.md) for full API.
 
-LSTM, BiLSTM, GRU, BiGRU, attention_lstm, resnet_lstm, TCN, WaveNet, cnn_lstm, cnn_gru, inception_lstm, transformer, MLP
+### Data Pipeline
 
-## Code Style
+`get_datasets(fd=1)` returns `((dev_X, dev_y), (val_X, val_y), (test_X, test_y))`. Each X is `List[np.ndarray]` with shape `(num_cycles, timesteps, num_sensors)`. `prepare_sequences()` in `train_model.py:68` flattens into `(N, timesteps, features)` arrays. `normalize_data()` at `train_model.py:100` fits `StandardScaler` on train, transforms all splits. See [src/data/CLAUDE.md](src/data/CLAUDE.md).
 
-- Black formatter (line-length: 100)
-- Python 3.8+ required
-- MyPy for type checking (relaxed settings)
+### Training Pipeline
+
+`train_model()` at `train_model.py:140` orchestrates the full loop: data prep, model build, W&B init, fit with callbacks (early stopping, LR reduction), evaluate, visualize, log to W&B. `compare_models()` at `train_model.py:497` runs multiple architectures back-to-back.
+
+### Inference Pipeline
+
+`RULPredictor` class in `predict.py` loads a saved model + scaler + config. `predict_single(sequence)` for one reading, `evaluate_test_set(fd)` for full evaluation with metrics. See [DEPLOYMENT.md](DEPLOYMENT.md) for full API docs.
+
+## How to Add a New Model Architecture
+
+1. Define class in `src/models/architectures.py` (or new file, imported in `architectures.py`)
+2. Inherit from `BaseModel` (line 84)
+3. Decorate with `@ModelRegistry.register("your_name")`
+4. Implement `static build(input_shape, units, dense_units, dropout_rate, learning_rate) -> keras.Model`
+5. Call `BaseModel.compile_model(model, learning_rate)` to compile with asymmetric_mse
+6. Update `get_model_info()` dict at `architectures.py:939`
+7. Update `get_model_recommendations()` dict at `architectures.py:965` if applicable
+8. Test: `python train_model.py --model your_name --epochs 5`
+9. Run `make check`
+
+See [src/models/CLAUDE.md](src/models/CLAUDE.md) for detailed patterns and custom layer inventory.
+
+## CI/CD
+
+GitHub Actions (`.github/workflows/ci.yml`) on push/PR to main:
+- Black formatting check
+- MyPy type checking
+- Matrix: Python 3.9, 3.10, 3.11
+- Tool: uv for dependency installation
+
+Always run `make check` before committing.
+
+## Development Workflow
+
+1. **Create a GitHub issue** with a full description of the work
+2. **Create a feature branch** from main
+3. **Develop and commit** — run `make check` before each commit
+4. **Open a PR** referencing the issue
+5. **Wait for CI to pass** before merging
+6. **Merge** the PR into main
+
+## Related Documentation
+
+- [README.md](README.md) — Quick start guide
+- [README_PRODUCTION.md](README_PRODUCTION.md) — 3-step production deployment
+- [DEPLOYMENT.md](DEPLOYMENT.md) — Full deployment guide, Python API, troubleshooting
+- [EXPERIMENTS.md](EXPERIMENTS.md) — SOTA architecture comparison (CNN-GRU winner)
+
+## Common Pitfalls
+
+- `train_model.py` is ~1000 lines — training logic lives here, NOT in `src/models/`
+- `src/models/__init__.py` uses lazy imports to avoid circular deps during CLI startup
+- Data downloads ~1GB on first use; cached in `data/raw/`
+- Full sequences are ~20k timesteps; truncate to 1000 (`max_sequence_length`) to avoid OOM
+- CNN-LSTM architecture does **not** converge; CNN-GRU is the stable hybrid variant
+- W&B requires `WANDB_API_KEY` env var, or set `WANDB_MODE=offline` for local runs
+- Larger models overfit on this dataset — 64 units outperforms 128 units (see [EXPERIMENTS.md](EXPERIMENTS.md))

--- a/src/data/CLAUDE.md
+++ b/src/data/CLAUDE.md
@@ -1,0 +1,44 @@
+# src/data/ — Data Loading
+
+## Purpose
+
+Download, cache, and load the NASA N-CMAPSS turbofan engine degradation dataset using the `rul_datasets` library. Single file module — all logic in `load_data.py`.
+
+## Key Functions
+
+### get_datasets(fd=1, data_dir="data/raw", cache=True)
+
+Main entry point. Returns:
+```
+((dev_X, dev_y), val_pair_or_None, (test_X, test_y))
+```
+
+- `dev` = training split, `test` = held-out evaluation
+- `val` may be `None` for some FD sub-datasets
+- Each X is `List[np.ndarray]` — one array per engine unit
+- Each unit array shape: `(num_cycles, timesteps, num_sensors)`
+- Each y is `List[np.ndarray]` — RUL values per cycle
+
+### download_ncmapss(data_dir, fd, cache)
+
+Downloads and prepares data via `NCmapssReader`. Called internally by `get_datasets`. Sets `RUL_DATASETS_DATA_ROOT` env var. First run downloads ~1GB.
+
+## Data Flow in Training
+
+1. `get_datasets()` returns `List[ndarray]` per split
+2. `prepare_sequences()` in `train_model.py:68` flattens into single arrays: `(N, timesteps, features)` and `(N,)`
+3. `normalize_data()` in `train_model.py:100` fits `StandardScaler` on train, transforms all splits
+4. Model receives `(batch, timesteps, features)` tensors
+
+See [../../CLAUDE.md](../../CLAUDE.md) for the full training pipeline overview.
+
+## Available Sub-datasets
+
+FD1 through FD7 (`--fd 1..7`). FD1 is the default and most commonly used. Different sub-datasets have different engine operating conditions and failure modes.
+
+## Pitfalls
+
+- First run triggers ~1GB download; ensure disk space and connectivity
+- Validation split may not exist for all FD values (returns `None`)
+- Full sequences can be ~20k timesteps; `train_model.py` truncates to 1000 via `max_sequence_length` to avoid OOM
+- Data is cached in `data/raw/` after first download — delete this directory to force re-download

--- a/src/models/CLAUDE.md
+++ b/src/models/CLAUDE.md
@@ -1,0 +1,87 @@
+# src/models/ — Model Architectures
+
+## Purpose
+
+All neural network architectures for RUL prediction. Uses a decorator-based ModelRegistry for easy model switching. See [../../EXPERIMENTS.md](../../EXPERIMENTS.md) for benchmark results.
+
+## Key Files
+
+- **architectures.py** — `ModelRegistry` class, `BaseModel` ABC, 12 built-in model classes, `asymmetric_mse` loss, custom layers (`AttentionLayer`, `TCNBlock`, `WaveNetBlock`)
+- **cnn_lstm_attention.py** — 2024 SOTA CNN-LSTM-Attention architecture (`SelfAttentionLayer`, `CNNFeatureExtractor`, `build_cnn_lstm_attention_model`)
+- **mdfa.py** — MDFA module (`ChannelAttention`, `SpatialAttention`, `MDFAModule`)
+- **__init__.py** — Lazy imports from `train_model.py` to avoid circular deps; re-exports `ModelRegistry`, `get_model`, `list_available_models`
+
+## ModelRegistry API
+
+| Method | Purpose |
+|--------|---------|
+| `ModelRegistry.register("name")` | Class decorator to register a model |
+| `ModelRegistry.build(name, input_shape, **kwargs)` | Build a compiled model by name |
+| `ModelRegistry.get(name)` | Get model class by name |
+| `ModelRegistry.list_models()` | List all registered names |
+| `get_model(name, input_shape, **kwargs)` | Convenience wrapper for `build()` |
+| `get_model_info()` (line 939) | Dict of name -> description |
+| `get_model_recommendations()` (line 965) | Dict of use_case -> [model_names] |
+
+## BaseModel Contract (line 84)
+
+Every model class must:
+1. Inherit from `BaseModel`
+2. Implement `static build(input_shape, units=64, dense_units=32, dropout_rate=0.2, learning_rate=0.001) -> keras.Model`
+3. Call `BaseModel.compile_model(model, learning_rate)` which sets:
+   - Optimizer: Adam
+   - Loss: `asymmetric_mse(alpha=2.0)`
+   - Metrics: `["mae", "mape"]`
+
+## Adding a New Model
+
+1. Add class to `architectures.py` (or new file, then import it in `architectures.py`)
+2. Decorate with `@ModelRegistry.register("my_model")`
+3. Implement `build()` following the `BaseModel` signature
+4. Call `BaseModel.compile_model()` for compilation
+5. Update `get_model_info()` dict (line 939)
+6. Update `get_model_recommendations()` dict (line 965) if applicable
+7. Test: `python train_model.py --model my_model --epochs 5`
+8. Run: `make check`
+
+## Registered Architectures (15 total)
+
+| Category | Models |
+|----------|--------|
+| RNN | `lstm`, `bilstm`, `gru`, `bigru`, `attention_lstm`, `resnet_lstm` |
+| Convolutional | `tcn`, `wavenet` |
+| Hybrid | `cnn_lstm`, `cnn_gru`, `inception_lstm` |
+| Attention | `transformer`, `mdfa`, `cnn_lstm_attention` |
+| Baseline | `mlp` |
+
+## Best Performing (see [../../EXPERIMENTS.md](../../EXPERIMENTS.md))
+
+1. **CNN-GRU** + asymmetric loss: RMSE 6.44, R² 0.91
+2. **WaveNet** + asymmetric loss: RMSE 6.73
+3. **Transformer** + asymmetric loss: RMSE 6.75
+
+CNN-LSTM does **not** converge. CNN-GRU is the stable hybrid variant.
+
+## asymmetric_mse Loss (line 64)
+
+Penalizes late predictions (`y_pred > y_true`) by `alpha=2.0x`. Over-predicting remaining life is dangerous in aviation — the engine might fail before the predicted end of life. This is the training loss; `phm_score` in [../utils/CLAUDE.md](../utils/CLAUDE.md) is the corresponding evaluation metric.
+
+## Custom Layers
+
+| Layer | File | Purpose |
+|-------|------|---------|
+| `AttentionLayer` | architectures.py | Additive attention for sequences |
+| `TCNBlock` | architectures.py | Dilated causal conv with residual connections |
+| `WaveNetBlock` | architectures.py | Gated dilated causal conv with residual |
+| `SelfAttentionLayer` | cnn_lstm_attention.py | Scaled dot-product Q/K/V attention |
+| `CNNFeatureExtractor` | cnn_lstm_attention.py | Conv1D stack with BatchNorm + pooling |
+| `ChannelAttention` | mdfa.py | SENet-style sensor importance weighting |
+| `SpatialAttention` | mdfa.py | Time window importance weighting |
+| `MDFAModule` | mdfa.py | Multi-scale dilated fusion + dual attention |
+
+## Pitfalls
+
+- `__init__.py` lazy-imports `train_model` functions to avoid circular deps — do not convert to top-level imports
+- `cnn_lstm_attention.py` has its own `asymmetric_mse` (duplicated from `architectures.py`) because it uses a standalone build function
+- Models expect `input_shape=(timesteps, features)` — no batch dimension
+- Some models accept extra kwargs (`num_heads`, `num_layers`, `kernel_size`, `dilation_rates`, `cnn_filters`) — check each `build()` signature

--- a/src/search/CLAUDE.md
+++ b/src/search/CLAUDE.md
@@ -1,0 +1,70 @@
+# src/search/ — Hyperparameter Search
+
+## Purpose
+
+Grid and random hyperparameter search with parallel execution and live worker throttling. Driven by JSON spec files. Single file module — all logic in `hparam_search.py`.
+
+## CLI Usage
+
+```bash
+# Grid search with 4 parallel workers
+python train_model.py --search-config spec.json --search-workers 4
+
+# Random search with live throttling
+python train_model.py --search-config spec.json --search-throttle-file workers.txt
+```
+
+## JSON Spec Format
+
+```json
+{
+  "name": "my_search",
+  "model": "cnn_gru",
+  "method": "grid",
+  "fd": 1,
+  "base_config": {
+    "epochs": 50,
+    "batch_size": 32
+  },
+  "parameters": {
+    "units": [32, 64, 128],
+    "learning_rate": [0.001, 0.0005]
+  }
+}
+```
+
+- `method`: `"grid"` (all combinations) or `"random"` (requires `"num_trials"`)
+- `base_config`: Defaults applied to every trial
+- `parameters`: Values to sweep over
+- Alternative: use an explicit `"trials"` array for hand-picked configs
+
+## Key Functions
+
+| Function | Purpose |
+|----------|---------|
+| `run_hparam_search(args)` | Main entry point, called from `train_model.py` CLI |
+| `load_search_spec(path)` | Load and validate JSON spec |
+| `generate_search_jobs(args, spec)` | Expand spec into concrete job dicts |
+| `execute_training_job(job)` | Run single training job (for multiprocessing) |
+| `read_worker_limit(default, throttle_file)` | Live worker count adjustment |
+
+## Live Throttling
+
+Write an integer to the throttle file to adjust workers mid-search:
+```bash
+echo 2 > workers.txt    # reduce to 2 workers
+echo 8 > workers.txt    # scale up to 8 workers
+```
+
+## Results
+
+Written to `results/search/{name}_results.json`.
+
+## Pitfalls
+
+- Each search worker loads the full dataset independently — memory-heavy with many workers
+- Lazy import of `train_model` in `execute_training_job` to avoid circular deps
+- `sys.path` manipulation to find project root (necessary for subprocess imports)
+- Grid search with many parameters creates combinatorial explosion — prefer random search for large spaces
+- Results are not aggregated with W&B automatically; each trial runs as a separate W&B run
+- See [../models/CLAUDE.md](../models/CLAUDE.md) for available model names and hyperparameter kwargs

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -1,0 +1,77 @@
+# src/utils/ — Metrics & Visualization
+
+## Purpose
+
+Evaluation metrics for RUL prediction and visualization utilities for training, data analysis, and model evaluation. All public functions are re-exported via `__init__.py` — import directly from `src.utils`.
+
+## Key Files
+
+### metrics.py — Evaluation Metrics
+
+**Core function**: `compute_all_metrics(y_true, y_pred, y_min=None, y_max=None) -> dict`
+Returns all metrics in one call. Pass `y_min`/`y_max` for normalized metrics (used for paper comparison).
+
+| Function | Purpose | Note |
+|----------|---------|------|
+| `rmse(y_true, y_pred)` | Root Mean Squared Error | Primary ranking metric |
+| `mape(y_true, y_pred)` | Mean Absolute Percentage Error | |
+| `phm_score(y_true, y_pred)` | Official PHM08 Challenge scoring | Lower is better; asymmetric |
+| `phm_score_normalized(y_true, y_pred)` | Per-sample average PHM | Easier to interpret |
+| `asymmetric_loss(y_true, y_pred, alpha)` | NumPy version of training loss | For evaluation only |
+| `rul_accuracy(y_true, y_pred, threshold)` | % predictions within threshold | Default threshold=10 |
+| `normalized_rmse(y_true, y_pred, y_min, y_max)` | RMSE on [0,1]-scaled RUL | For SOTA comparison |
+| `normalized_mae(y_true, y_pred, y_min, y_max)` | MAE on [0,1]-scaled RUL | For SOTA comparison |
+| `compare_models(results_dict, primary_metric)` | Find best model from results | |
+| `format_metrics(metrics_dict)` | Pretty-print metrics string | |
+
+### training_viz.py — Training Visualization
+
+| Function | Purpose |
+|----------|---------|
+| `plot_training_history(history, model_name, save_path)` | Loss/accuracy curves |
+| `plot_predictions(y_true, y_pred, model_name, save_path)` | Actual vs predicted scatter |
+| `plot_error_distribution(y_true, y_pred, model_name, save_path)` | Error histogram |
+| `plot_model_comparison(results, metrics, save_path)` | Multi-model side-by-side bars |
+| `plot_sample_predictions(y_true, y_pred, model_name, save_path)` | Sample-level predictions |
+| `create_evaluation_report(model_name, metrics, y_true, y_pred, history, save_dir)` | Full report to directory |
+
+### visualize.py — Data Analysis & Model Eval (28KB)
+
+**Data analysis**: `plot_sensor_degradation`, `plot_sensor_correlation_heatmap`, `plot_multi_sensor_lifecycle`
+
+**Model evaluation**: `plot_rul_trajectory`, `plot_critical_zone_analysis`, `plot_prediction_confidence`
+
+**Basic**: `plot_rul_distribution`, `plot_sensor_time_series`, `visualize_dataset`
+
+## Import Pattern
+
+All functions re-exported via `__init__.py`:
+```python
+from src.utils import compute_all_metrics, plot_training_history, rmse
+```
+
+## Adding a New Metric
+
+1. Add function in `metrics.py` following existing signature `(y_true, y_pred, ...) -> float`
+2. Add to `compute_all_metrics()` return dict if it should always be computed
+3. Add to `format_metrics()` for display formatting
+4. Export in `__init__.py`
+5. Run `make check`
+
+## Adding a New Visualization
+
+1. Add function in `training_viz.py` (training-related) or `visualize.py` (data/eval)
+2. Follow pattern: accept `save_path=None`, call `plt.savefig()` if provided, else `plt.show()`
+3. Export in `__init__.py`
+4. Run `make check`
+
+## PHM Score Explained
+
+The PHM08 scoring function is the standard metric for RUL prediction competitions. It is exponentially asymmetric: late predictions (thinking the engine has more life than it does) are penalized ~3x more than early predictions at the same error magnitude. This aligns with the safety-critical nature of the domain.
+
+```
+s_i = exp(-d/13) - 1   if d < 0  (early prediction — less severe)
+s_i = exp(d/10)  - 1   if d >= 0 (late prediction — dangerous)
+```
+
+See [../models/CLAUDE.md](../models/CLAUDE.md) for the corresponding `asymmetric_mse` training loss.


### PR DESCRIPTION
## Summary
- Rewrote root `CLAUDE.md` with comprehensive quick reference, cross-referenced architecture overview, pipeline docs, and common pitfalls
- Created nested `CLAUDE.md` files in `src/models/`, `src/data/`, `src/utils/`, and `src/search/` with module-specific API docs, how-to guides, and inter-file references
- All cross-references point to existing docs (`EXPERIMENTS.md`, `DEPLOYMENT.md`, `README.md`, `README_PRODUCTION.md`) and between nested files

## Test plan
- [x] `make check` passes (lint + typecheck)
- [x] All cross-referenced file paths verified to exist
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)