### PR TITLE
Add mstcn_noncausal: non-causal TCN with doubled receptive field

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -56,6 +56,7 @@ def get_model_info() -> dict[str, str]:
         "atcn": "ATCN - Attention-based TCN with ISA and squeeze-excitation (2023 SOTA)",
         "sparse_transformer_bigrcu": "Sparse Transformer+Bi-GRCU - LRLS attention, most recent (2025 SOTA)",
         "mstcn": "MSTCN - Multi-scale TCN with Global Fusion Attention (2024 SOTA)",
+        "mstcn_noncausal": "MSTCN with non-causal (same) padding — doubled receptive field for offline prediction",
         "mlp": "Simple MLP - baseline for comparison (no temporal modeling)",
     }
 
@@ -67,6 +68,7 @@ def get_model_recommendations() -> dict[str, list]:
         "best_accuracy": [
             "sparse_transformer_bigrcu",
             "mstcn",
+            "mstcn_noncausal",
             "ttsnet",
             "atcn",
             "cata_tcn",
@@ -80,6 +82,7 @@ def get_model_recommendations() -> dict[str, list]:
         "long_sequences": [
             "sparse_transformer_bigrcu",
             "mstcn",
+            "mstcn_noncausal",
             "ttsnet",
             "atcn",
             "mdfa",

--- a/src/models/cata_tcn.py
+++ b/src/models/cata_tcn.py
@@ -28,6 +28,7 @@ class ResidualTCNBlock(layers.Layer):
         kernel_size: int,
         dilation_rate: int,
         dropout_rate: float,
+        causal: bool = True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -35,19 +36,21 @@ class ResidualTCNBlock(layers.Layer):
         self.kernel_size = kernel_size
         self.dilation_rate = dilation_rate
         self.dropout_rate = dropout_rate
+        self.causal = causal
 
+        padding = "causal" if self.causal else "same"
         self.conv1 = layers.Conv1D(
             filters=filters,
             kernel_size=kernel_size,
             dilation_rate=dilation_rate,
-            padding="causal",
+            padding=padding,
             activation="relu",
         )
         self.conv2 = layers.Conv1D(
             filters=filters,
             kernel_size=kernel_size,
             dilation_rate=dilation_rate,
-            padding="causal",
+            padding=padding,
             activation="relu",
         )
         self.drop1 = layers.Dropout(dropout_rate)
@@ -66,6 +69,19 @@ class ResidualTCNBlock(layers.Layer):
         x = self.drop2(x, training=training)
         residual = self.proj(inputs) if self.proj is not None else inputs
         return layers.add([x, residual])
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "filters": self.filters,
+                "kernel_size": self.kernel_size,
+                "dilation_rate": self.dilation_rate,
+                "dropout_rate": self.dropout_rate,
+                "causal": self.causal,
+            }
+        )
+        return config
 
 
 class ChannelAttention1D(layers.Layer):

--- a/src/models/mstcn.py
+++ b/src/models/mstcn.py
@@ -228,3 +228,84 @@ def build_mstcn_model(
         metrics=["mae", "mape"],
     )
     return model
+
+
+def build_mstcn_noncausal_model(
+    input_shape: Tuple[int, int],
+    units: int = 64,
+    dense_units: int = 32,
+    dropout_rate: float = 0.2,
+    learning_rate: float = 0.001,
+    kernel_size: int = 3,
+    dilation_rates: List[int] = None,
+) -> keras.Model:
+    """
+    Build non-causal MSTCN model for offline/batch RUL prediction.
+
+    Identical to ``build_mstcn_model`` but uses ``padding='same'`` in every
+    ``ResidualTCNBlock`` instead of ``padding='causal'``.  Because each
+    convolution can see both past *and* future context within the window, the
+    effective receptive field is doubled without adding parameters.  This is
+    only valid for offline (non-streaming) inference where the full sequence is
+    available at prediction time.
+
+    Args:
+        input_shape: (sequence_length, num_features)
+        units: Number of filters in TCN blocks
+        dense_units: Number of units in final dense layer
+        dropout_rate: Dropout probability
+        learning_rate: Optimizer learning rate
+        kernel_size: Kernel size for TCN convolutions
+        dilation_rates: List of dilation rates for multi-scale branches
+                       (default: [1, 2, 4, 8])
+
+    Returns:
+        Compiled Keras model
+    """
+    if dilation_rates is None:
+        dilation_rates = [1, 2, 4, 8]
+
+    num_scales = len(dilation_rates)
+
+    inputs = layers.Input(shape=input_shape, name="input")
+
+    tcn_outputs = []
+    for i, dilation_rate in enumerate(dilation_rates):
+        branch = inputs
+
+        branch = ResidualTCNBlock(
+            filters=units,
+            kernel_size=kernel_size,
+            dilation_rate=dilation_rate,
+            dropout_rate=dropout_rate,
+            causal=False,
+            name=f"tcn_scale{i}_block1",
+        )(branch)
+
+        branch = ResidualTCNBlock(
+            filters=units,
+            kernel_size=kernel_size,
+            dilation_rate=dilation_rate,
+            dropout_rate=dropout_rate,
+            causal=False,
+            name=f"tcn_scale{i}_block2",
+        )(branch)
+
+        tcn_outputs.append(branch)
+
+    fused = GlobalFusionAttention(num_scales=num_scales, reduction_ratio=8, name="global_fusion")(
+        tcn_outputs
+    )
+
+    x = layers.GlobalAveragePooling1D(name="global_pooling")(fused)
+    x = layers.Dense(dense_units, activation="relu", name="dense_1")(x)
+    x = layers.Dropout(dropout_rate, name="dropout")(x)
+    outputs = layers.Dense(1, activation="linear", name="output")(x)
+
+    model = keras.Model(inputs=inputs, outputs=outputs, name="mstcn_noncausal")
+    model.compile(
+        optimizer=keras.optimizers.Adam(learning_rate=learning_rate),
+        loss=asymmetric_mse(),
+        metrics=["mae", "mape"],
+    )
+    return model

--- a/src/models/sota.py
+++ b/src/models/sota.py
@@ -9,7 +9,7 @@ from src.models.base import BaseModel
 from src.models.cata_tcn import build_cata_tcn_model
 from src.models.cnn_lstm_attention import build_cnn_lstm_attention_model
 from src.models.mdfa import MDFAModule
-from src.models.mstcn import build_mstcn_model
+from src.models.mstcn import build_mstcn_model, build_mstcn_noncausal_model
 from src.models.registry import ModelRegistry
 from src.models.sparse_transformer_bigrcu import build_sparse_transformer_bigrcu_model
 from src.models.ttsnet import build_ttsnet_model
@@ -198,6 +198,38 @@ class MSTCNModel(BaseModel):
         dilation_rates: list = None,
     ) -> keras.Model:
         return build_mstcn_model(
+            input_shape=input_shape,
+            units=units,
+            dense_units=dense_units,
+            dropout_rate=dropout_rate,
+            learning_rate=learning_rate,
+            kernel_size=kernel_size,
+            dilation_rates=dilation_rates,
+        )
+
+
+@ModelRegistry.register("mstcn_noncausal")
+class MSTCNNonCausal(BaseModel):
+    """MSTCN with non-causal (bidirectional context) convolutions.
+
+    Uses ``padding='same'`` instead of ``padding='causal'`` in every
+    ``ResidualTCNBlock``.  Each dilated convolution can attend to both past and
+    future timesteps within the window, doubling the effective receptive field
+    without any additional parameters.  Only valid for offline/batch prediction
+    where the full sequence is available at inference time.
+    """
+
+    @staticmethod
+    def build(
+        input_shape: Tuple[int, int],
+        units: int = 64,
+        dense_units: int = 32,
+        dropout_rate: float = 0.2,
+        learning_rate: float = 0.001,
+        kernel_size: int = 3,
+        dilation_rates: list = None,
+    ) -> keras.Model:
+        return build_mstcn_noncausal_model(
             input_shape=input_shape,
             units=units,
             dense_units=dense_units,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,6 +70,7 @@ class TestModelRegistry:
             "atcn",
             "sparse_transformer_bigrcu",
             "mstcn",
+            "mstcn_noncausal",
         }
         assert expected.issubset(registered), f"Missing models: {expected - registered}"
 


### PR DESCRIPTION
## Summary
- `ResidualTCNBlock` gains a `causal: bool = True` param — backward compatible
- `causal=False` switches `padding='causal'` → `padding='same'`, doubling effective receptive field at zero parameter cost
- New `mstcn_noncausal` model registered via `MSTCNNonCausal` in `sota.py`
- Valid for offline/batch RUL prediction (full sequence available at inference time)

## Test plan
- [ ] `mstcn_noncausal` appears in `ModelRegistry.list_models()`
- [ ] Smoke test: builds and runs forward pass for `(50, 6)` input
- [ ] Existing causal TCN models unaffected (backward compatible default)
- [ ] CI passes

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)