### PR TITLE
Add uncertainty_mstcn: MSTCN with aleatoric uncertainty via NLL loss

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -18,6 +18,7 @@ from src.models import cnn  # noqa: F401
 from src.models import hybrid  # noqa: F401
 from src.models import rnn  # noqa: F401
 from src.models import sota  # noqa: F401
+from src.models import uncertainty_mstcn  # noqa: F401
 
 
 def get_model(
@@ -56,6 +57,7 @@ def get_model_info() -> dict[str, str]:
         "atcn": "ATCN - Attention-based TCN with ISA and squeeze-excitation (2023 SOTA)",
         "sparse_transformer_bigrcu": "Sparse Transformer+Bi-GRCU - LRLS attention, most recent (2025 SOTA)",
         "mstcn": "MSTCN - Multi-scale TCN with Global Fusion Attention (2024 SOTA)",
+        "uncertainty_mstcn": "Uncertainty-MSTCN - MSTCN with aleatoric uncertainty head, outputs mean + log-var, NLL loss",
         "mlp": "Simple MLP - baseline for comparison (no temporal modeling)",
     }
 

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -17,6 +17,26 @@ def asymmetric_mse(alpha: float = 2.0):
     return loss
 
 
+def nll_loss():
+    """Negative log-likelihood loss for dual-output uncertainty models.
+
+    Model output is expected to be shape (batch, 2): [mean, log_var]
+    y_true is shape (batch, 1) or (batch,)
+    Loss = 0.5 * (log_var + (y_true - mean)^2 / exp(log_var))
+    """
+
+    def loss(y_true: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
+        mean = y_pred[:, 0:1]
+        log_var = y_pred[:, 1:2]
+        # Clamp log_var for numerical stability
+        log_var = tf.clip_by_value(log_var, -10.0, 10.0)
+        var = tf.exp(log_var)
+        y_true_flat = tf.reshape(y_true, tf.shape(mean))
+        return tf.reduce_mean(0.5 * (log_var + tf.square(y_true_flat - mean) / var))
+
+    return loss
+
+
 def get_loss_function(loss_name: str = "asymmetric_mse", loss_alpha: float = 2.0):
     """Resolve a configured training loss."""
     losses = {
@@ -25,6 +45,7 @@ def get_loss_function(loss_name: str = "asymmetric_mse", loss_alpha: float = 2.0
         "mae": keras.losses.MeanAbsoluteError(),
         "huber": keras.losses.Huber(),
         "log_cosh": keras.losses.LogCosh(),
+        "nll": nll_loss(),
     }
     if loss_name not in losses:
         available = ", ".join(sorted(losses))

--- a/src/models/uncertainty_mstcn.py
+++ b/src/models/uncertainty_mstcn.py
@@ -1,0 +1,114 @@
+"""
+Aleatoric uncertainty MSTCN variant.
+
+Identical to the MSTCN architecture up to the shared dense representation,
+then splits into two output heads:
+  - mean_output : predicted RUL (linear)
+  - log_var_output : log-variance of the aleatoric uncertainty (linear)
+
+Concatenated output shape: (batch, 2) — [mean, log_var]
+Trained with Negative Log-Likelihood (NLL) loss from base.py.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+
+from src.models.base import BaseModel, nll_loss
+from src.models.cata_tcn import ResidualTCNBlock
+from src.models.mstcn import GlobalFusionAttention
+from src.models.registry import ModelRegistry
+
+
+@ModelRegistry.register("uncertainty_mstcn")
+class UncertaintyMSTCN(BaseModel):
+    """MSTCN with an aleatoric uncertainty head.
+
+    Outputs a concatenated (batch, 2) tensor: [mean_rul, log_var].
+    Trained with NLL loss; confidence intervals can be derived from log_var.
+    """
+
+    @staticmethod
+    def build(
+        input_shape: Tuple[int, int],
+        units: int = 64,
+        dense_units: int = 32,
+        dropout_rate: float = 0.2,
+        learning_rate: float = 0.001,
+        kernel_size: int = 3,
+        dilation_rates: List[int] = None,
+    ) -> keras.Model:
+        """Build and compile the uncertainty MSTCN model.
+
+        Args:
+            input_shape: (sequence_length, num_features)
+            units: Number of filters in TCN blocks
+            dense_units: Number of units in final dense layer
+            dropout_rate: Dropout probability
+            learning_rate: Optimizer learning rate
+            kernel_size: Kernel size for TCN convolutions
+            dilation_rates: Dilation rates for multi-scale branches (default: [1, 2, 4, 8])
+
+        Returns:
+            Compiled Keras model with output shape (batch, 2): [mean, log_var]
+        """
+        if dilation_rates is None:
+            dilation_rates = [1, 2, 4, 8]
+
+        num_scales = len(dilation_rates)
+
+        inputs = layers.Input(shape=input_shape, name="input")
+
+        # Multi-Scale TCN: parallel branches with different dilation rates
+        tcn_outputs = []
+        for i, dilation_rate in enumerate(dilation_rates):
+            branch = inputs
+
+            # First TCN block
+            branch = ResidualTCNBlock(
+                filters=units,
+                kernel_size=kernel_size,
+                dilation_rate=dilation_rate,
+                dropout_rate=dropout_rate,
+                name=f"tcn_scale{i}_block1",
+            )(branch)
+
+            # Second TCN block (same dilation for deeper receptive field)
+            branch = ResidualTCNBlock(
+                filters=units,
+                kernel_size=kernel_size,
+                dilation_rate=dilation_rate,
+                dropout_rate=dropout_rate,
+                name=f"tcn_scale{i}_block2",
+            )(branch)
+
+            tcn_outputs.append(branch)
+
+        # Global Fusion Attention: intelligently combine multi-scale features
+        fused = GlobalFusionAttention(num_scales=num_scales, reduction_ratio=8, name="global_fusion")(
+            tcn_outputs
+        )
+
+        # Global pooling to get fixed-size representation
+        shared = layers.GlobalAveragePooling1D(name="global_pooling")(fused)
+
+        # Shared dense representation
+        shared = layers.Dense(dense_units, activation="relu", name="dense_1")(shared)
+        shared = layers.Dropout(dropout_rate, name="dropout")(shared)
+
+        # Dual output heads
+        mean_output = layers.Dense(1, activation="linear", name="mean")(shared)
+        log_var_output = layers.Dense(1, activation="linear", name="log_var")(shared)
+        outputs = layers.Concatenate(name="output")([mean_output, log_var_output])
+
+        model = keras.Model(inputs=inputs, outputs=outputs, name="uncertainty_mstcn")
+        model.compile(
+            optimizer=keras.optimizers.Adam(learning_rate=learning_rate),
+            loss=nll_loss(),
+            metrics=[],  # no standard metrics — output shape is (batch, 2)
+        )
+        return model

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,0 +1,79 @@
+"""Tests for aleatoric uncertainty MSTCN and NLL loss."""
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from src.models import uncertainty_mstcn  # noqa: F401 — trigger registration
+from src.models.base import nll_loss
+from src.models.registry import ModelRegistry
+
+
+SMALL_INPUT_SHAPE = (50, 6)
+BATCH_SIZE = 4
+
+
+class TestNLLLoss:
+    """Tests for the NLL loss function."""
+
+    def test_nll_loss_returns_scalar(self):
+        loss_fn = nll_loss()
+        y_true = tf.constant([[10.0], [20.0], [30.0]])
+        # Output: [mean, log_var] — low log_var, mean close to y_true
+        y_pred = tf.constant([[10.0, 0.0], [20.0, 0.0], [30.0, 0.0]])
+        loss_val = loss_fn(y_true, y_pred)
+        assert loss_val.shape == ()
+
+    def test_nll_loss_lower_when_mean_closer(self):
+        """Loss should be lower when mean is closer to target."""
+        loss_fn = nll_loss()
+        y_true = tf.constant([[10.0]])
+        good_pred = tf.constant([[10.0, 0.0]])  # exact mean, log_var=0
+        bad_pred = tf.constant([[50.0, 0.0]])  # far from target
+        assert loss_fn(y_true, good_pred) < loss_fn(y_true, bad_pred)
+
+    def test_nll_loss_finite_on_extreme_log_var(self):
+        """Loss should remain finite when log_var is clamped."""
+        loss_fn = nll_loss()
+        y_true = tf.constant([[10.0]])
+        y_pred = tf.constant([[10.0, 100.0]])  # extreme log_var — clamped to 10
+        loss_val = loss_fn(y_true, y_pred)
+        assert tf.math.is_finite(loss_val)
+
+
+class TestUncertaintyMSTCN:
+    """Tests for the uncertainty_mstcn model."""
+
+    def test_builds_successfully(self):
+        model = ModelRegistry.build("uncertainty_mstcn", input_shape=SMALL_INPUT_SHAPE)
+        assert model is not None
+
+    def test_output_shape_is_batch_2(self):
+        model = ModelRegistry.build("uncertainty_mstcn", input_shape=SMALL_INPUT_SHAPE)
+        assert model.output_shape == (None, 2), f"Expected (None, 2), got {model.output_shape}"
+
+    def test_forward_pass_produces_finite_values(self):
+        model = ModelRegistry.build("uncertainty_mstcn", input_shape=SMALL_INPUT_SHAPE)
+        x = np.random.randn(BATCH_SIZE, *SMALL_INPUT_SHAPE).astype(np.float32)
+        preds = model(x, training=False)
+        assert preds.shape == (BATCH_SIZE, 2)
+        assert np.all(np.isfinite(preds.numpy())), "Predictions contain non-finite values"
+
+    def test_std_from_log_var_is_positive(self):
+        """Std derived from log_var output should be > 0."""
+        model = ModelRegistry.build("uncertainty_mstcn", input_shape=SMALL_INPUT_SHAPE)
+        x = np.random.randn(BATCH_SIZE, *SMALL_INPUT_SHAPE).astype(np.float32)
+        preds = model(x, training=False).numpy()
+        log_var = preds[:, 1]
+        std = np.sqrt(np.exp(np.clip(log_var, -10, 10)))
+        assert np.all(std > 0), "All std values should be positive"
+
+    def test_is_registered_in_model_registry(self):
+        from src.models.registry import ModelRegistry as MR
+
+        assert "uncertainty_mstcn" in MR.list_models()
+
+    def test_model_has_optimizer_and_loss(self):
+        model = ModelRegistry.build("uncertainty_mstcn", input_shape=SMALL_INPUT_SHAPE)
+        assert model.optimizer is not None
+        assert model.loss is not None


### PR DESCRIPTION
## Summary
- `nll_loss()` added to `src/models/base.py` — negative log-likelihood for dual-output models, with log_var clamped to [-10, 10] for stability
- `uncertainty_mstcn` registered: identical MSTCN backbone, final dense head splits into `mean` + `log_var` outputs (shape `(batch, 2)`)
- Confidence interval at inference: `std = sqrt(exp(log_var))`
- 9 new unit tests in `tests/test_uncertainty.py`

## Test plan
- [ ] `nll_loss` returns scalar, decreases when mean approaches target, stays finite on extreme log_var
- [ ] Model output shape is `(None, 2)`
- [ ] `std > 0` for all predictions
- [ ] CI passes

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)