### PR TITLE
Add critical-zone loss weighting, MC Dropout uncertainty, monotonic inference

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -251,6 +251,49 @@ class RULPredictor:
         else:
             return "LOW"
 
+    def predict_with_uncertainty(
+        self, sequence: np.ndarray, n_passes: int = 50
+    ) -> Tuple[float, float]:
+        """Estimate prediction uncertainty via MC Dropout.
+
+        Runs ``n_passes`` stochastic forward passes with dropout active and
+        returns the mean and standard deviation of the resulting predictions.
+        No architectural changes required — existing dropout layers provide the
+        stochasticity.
+
+        Args:
+            sequence: Raw sensor data (timesteps, features)
+            n_passes: Number of Monte Carlo forward passes (default: 50)
+
+        Returns:
+            (mean_rul, std_rul) — point estimate and epistemic uncertainty.
+        """
+        spec = self.model_specs[0]
+        X = self._prepare_single(sequence, spec["max_seq_length"], spec["scaler"])
+        preds = []
+        for _ in range(n_passes):
+            # training=True keeps dropout active during inference
+            raw = float(spec["model"](X, training=True)[0, 0])
+            preds.append(self._inverse_transform_prediction(raw, spec["target_transform"]))
+        return float(np.mean(preds)), float(np.std(preds))
+
+    def predict_monotonic(self, sequences: List[np.ndarray]) -> np.ndarray:
+        """Predict RUL for consecutive engine readings, enforcing monotonic decrease.
+
+        Applies a cumulative minimum so that the predicted RUL never increases
+        between consecutive timesteps, which is physically required (degradation
+        is irreversible).
+
+        Args:
+            sequences: List of raw sensor arrays, one per timestep
+                       Each element: (timesteps, features)
+
+        Returns:
+            Monotonically non-increasing RUL predictions, shape (len(sequences),)
+        """
+        raw_preds = np.array([self.predict_single(seq)["prediction"] for seq in sequences])
+        return np.minimum.accumulate(raw_preds)
+
     def predict_unit(
         self, unit_X: np.ndarray, unit_y: np.ndarray
     ) -> Tuple[np.ndarray, np.ndarray, List[Dict]]:

--- a/tests/test_zone_weights_and_inference.py
+++ b/tests/test_zone_weights_and_inference.py
@@ -1,0 +1,146 @@
+"""Tests for critical-zone sample weighting, MC Dropout, and monotonic inference."""
+
+import numpy as np
+import pytest
+
+
+class TestComputeZoneWeights:
+    """Tests for compute_zone_weights() in train_model.py."""
+
+    def _fn(self):
+        from train_model import compute_zone_weights
+
+        return compute_zone_weights
+
+    def test_returns_same_shape(self):
+        fn = self._fn()
+        y = np.array([5.0, 35.0, 100.0])
+        w = fn(y)
+        assert w.shape == y.shape
+
+    def test_critical_zone_weight(self):
+        fn = self._fn()
+        y = np.array([0.0, 15.0, 30.0])
+        w = fn(y)
+        assert np.allclose(w, 2.5), f"Expected 2.5 for critical zone, got {w}"
+
+    def test_warning_zone_weight(self):
+        fn = self._fn()
+        y = np.array([31.0, 50.0, 80.0])
+        w = fn(y)
+        assert np.allclose(w, 1.5), f"Expected 1.5 for warning zone, got {w}"
+
+    def test_normal_zone_weight(self):
+        fn = self._fn()
+        y = np.array([81.0, 120.0, 200.0])
+        w = fn(y)
+        assert np.allclose(w, 1.0), f"Expected 1.0 for normal zone, got {w}"
+
+    def test_dtype_is_float32(self):
+        fn = self._fn()
+        y = np.array([10.0, 50.0, 100.0])
+        w = fn(y)
+        assert w.dtype == np.float32
+
+
+class TestMCDropoutUncertainty:
+    """Tests for RULPredictor.predict_with_uncertainty()."""
+
+    def _make_predictor(self):
+        """Build a minimal RULPredictor with a tiny MSTCN model."""
+        import tensorflow as tf
+        from tensorflow import keras
+        from tensorflow.keras import layers
+
+        # Simple model with dropout (required for MC Dropout to work)
+        inputs = layers.Input(shape=(20, 4))
+        x = layers.Dense(16, activation="relu")(inputs)
+        x = layers.Dropout(0.3)(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        outputs = layers.Dense(1)(x)
+        model = keras.Model(inputs, outputs)
+        model.compile(optimizer="adam", loss="mse")
+
+        from predict import RULPredictor
+
+        predictor = RULPredictor.__new__(RULPredictor)
+        predictor.model_specs = [
+            {
+                "model": model,
+                "max_seq_length": 20,
+                "scaler": None,
+                "target_transform": {"method": "none", "scale_min": 0.0, "scale_max": 1.0},
+                "name": "test_model",
+            }
+        ]
+        predictor.ensemble = None
+        predictor.ensemble_weights = None
+        return predictor
+
+    def test_returns_tuple_of_two_floats(self):
+        predictor = self._make_predictor()
+        sequence = np.random.randn(20, 4).astype(np.float32)
+        mean, std = predictor.predict_with_uncertainty(sequence, n_passes=10)
+        assert isinstance(mean, float)
+        assert isinstance(std, float)
+
+    def test_std_is_non_negative(self):
+        predictor = self._make_predictor()
+        sequence = np.random.randn(20, 4).astype(np.float32)
+        _, std = predictor.predict_with_uncertainty(sequence, n_passes=10)
+        assert std >= 0.0
+
+    def test_mean_is_finite(self):
+        predictor = self._make_predictor()
+        sequence = np.random.randn(20, 4).astype(np.float32)
+        mean, _ = predictor.predict_with_uncertainty(sequence, n_passes=10)
+        assert np.isfinite(mean)
+
+
+class TestMonotonicPredictions:
+    """Tests for RULPredictor.predict_monotonic()."""
+
+    def _make_predictor_with_known_predictions(self, predictions):
+        """Build a mock predictor that returns given predictions in sequence."""
+        from unittest.mock import MagicMock
+
+        from predict import RULPredictor
+
+        predictor = RULPredictor.__new__(RULPredictor)
+        predictor.model_specs = [{}]  # non-empty
+        predictor.ensemble = None
+        predictor.ensemble_weights = None
+
+        # Patch predict_single to return values from the list
+        call_count = [0]
+
+        def mock_predict_single(seq):
+            idx = call_count[0]
+            call_count[0] += 1
+            return {"prediction": predictions[idx]}
+
+        predictor.predict_single = mock_predict_single
+        return predictor
+
+    def test_output_is_non_increasing(self):
+        preds = [100.0, 95.0, 105.0, 80.0, 85.0]  # non-monotonic raw preds
+        predictor = self._make_predictor_with_known_predictions(preds)
+        sequences = [np.zeros((5, 3)) for _ in preds]
+        result = predictor.predict_monotonic(sequences)
+        # After cumulative min: [100, 95, 95, 80, 80]
+        for i in range(1, len(result)):
+            assert result[i] <= result[i - 1], f"result[{i}]={result[i]} > result[{i-1}]={result[i-1]}"
+
+    def test_already_monotonic_is_unchanged(self):
+        preds = [100.0, 90.0, 80.0, 70.0]
+        predictor = self._make_predictor_with_known_predictions(preds)
+        sequences = [np.zeros((5, 3)) for _ in preds]
+        result = predictor.predict_monotonic(sequences)
+        assert np.allclose(result, preds)
+
+    def test_output_shape(self):
+        preds = [50.0, 40.0, 45.0]
+        predictor = self._make_predictor_with_known_predictions(preds)
+        sequences = [np.zeros((5, 3)) for _ in preds]
+        result = predictor.predict_monotonic(sequences)
+        assert result.shape == (3,)

--- a/train_model.py
+++ b/train_model.py
@@ -177,6 +177,26 @@ def normalize_data(
     return X_train_norm, X_val_norm, X_test_norm, scaler
 
 
+def compute_zone_weights(y: np.ndarray) -> np.ndarray:
+    """Compute per-sample weights emphasizing critical (low-RUL) zones.
+
+    Three zones based on RUL value:
+      - Critical zone  (RUL <= 30):        weight 2.5  (most safety-critical)
+      - Warning zone   (30 < RUL <= 80):   weight 1.5
+      - Normal zone    (RUL > 80):         weight 1.0
+
+    Args:
+        y: RUL target array, shape (N,)
+
+    Returns:
+        Per-sample weight array of the same shape, dtype float32.
+    """
+    weights = np.ones_like(y, dtype=np.float32)
+    weights[y <= 30] = 2.5
+    weights[(y > 30) & (y <= 80)] = 1.5
+    return weights
+
+
 def clip_rul_targets(y: np.ndarray, max_rul: Optional[float] = None) -> np.ndarray:
     """Cap RUL targets at ``max_rul`` when configured."""
     clipped = np.asarray(y, dtype=np.float32).copy()
@@ -513,6 +533,7 @@ def train_model(
         "patience_early_stop": 10,
         "patience_lr_reduce": 5,
         "use_early_stop": True,
+        "critical_zone_weights": False,
     }
 
     if config is None:
@@ -645,6 +666,12 @@ def train_model(
             )
         )
 
+    # Compute optional critical-zone sample weights
+    sample_weight = None
+    if config.get("critical_zone_weights", False):
+        sample_weight = compute_zone_weights(y_train_fit)
+        print("Critical-zone weighting enabled (2.5x / 1.5x / 1.0x by RUL bucket)")
+
     # Train model
     print("\nStarting training...")
     history = model.fit(
@@ -655,6 +682,7 @@ def train_model(
         validation_data=(X_val, y_val_fit) if X_val is not None and y_val_fit is not None else None,
         validation_split=config["validation_split"] if validation_data is None else None,
         callbacks=callbacks,
+        sample_weight=sample_weight,
         verbose=1,
     )
 
@@ -1381,6 +1409,13 @@ Examples:
         help="Optional file containing an integer worker count that can be edited live",
     )
 
+    parser.add_argument(
+        "--critical-zone-weights",
+        action="store_true",
+        default=False,
+        help="Weight training samples by RUL zone (2.5x critical ≤30, 1.5x warning ≤80, 1.0x normal)",
+    )
+
     # Reproducibility options
     parser.add_argument(
         "--seed",
@@ -1474,6 +1509,9 @@ Examples:
             "patience_lr_reduce", args.patience_lr_reduce
         ),
         "use_early_stop": json_training_config.get("use_early_stop", not args.no_early_stop),
+        "critical_zone_weights": json_training_config.get(
+            "critical_zone_weights", args.critical_zone_weights
+        ),
     }
 
     # Compare mode


### PR DESCRIPTION
## Summary
- `compute_zone_weights()`: per-sample weights 2.5x (RUL≤30), 1.5x (RUL≤80), 1.0x (normal) — emphasizes safety-critical end-of-life predictions during training
- `--critical-zone-weights` CLI flag passes weights to `model.fit(sample_weight=)`
- `predict_with_uncertainty(n_passes=50)`: MC Dropout — runs n stochastic forward passes with `training=True`, returns `(mean_rul, std_rul)` — zero architectural changes required
- `predict_monotonic(sequences)`: post-processes predictions with `cumulative_min` to enforce physically required RUL monotonicity

## Test plan
- [ ] Zone weights: correct values (2.5/1.5/1.0) for each bucket, float32 dtype
- [ ] MC Dropout: returns `(float, float)` with `std >= 0`, mean is finite
- [ ] Monotonic: output is non-increasing, unchanged if already monotonic
- [ ] CI passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)